### PR TITLE
(Fixed) problem with comparator two APIData classes and its inheritors

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -222,7 +222,7 @@ class APIData(object, metaclass=BaseAPIMetaClass):
         #     API.CustomInitConnectionList.remove(self)
 
     def __eq__(self, __o: APIData) -> bool:
-        if type(__o) != APIData:
+        if not isinstance(__o, APIData):
             return False
         return self.pid == __o.pid
 


### PR DESCRIPTION
This construction not correctly work with APIData inhertitors. Fixed it.
This fix should close #58. My test tdata with few accounts in it works fine after fix.